### PR TITLE
double timeout time for a build step

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -140,6 +140,7 @@ opencog_master_precise.addStep(Test(
 # Builder for OpenCog Master Branch Build and Test on Ubuntu 14.04
 opencog_master_trusty = BuildFactory()
 opencog_master_trusty.workdir = "source"
+opencog_master_trusty.timeout = 2400
 
 opencog_master_trusty.addStep(Git(
                 repourl = 'git://github.com/opencog/opencog.git', 


### PR DESCRIPTION
A fix for interruption of buildbot step that lasts longer than 1200 sec. Reported on https://github.com/opencog/opencog/pull/1377#issuecomment-78013910 . 