### PR TITLE
add a script for cronjobs for building docker images 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,22 @@ different robots to be brought up and demoed.
 
 
 ## 2. Dockerfiles for OpenCog
-The dockerfiles here are designed to be built opencog-deps in the same directory
-as this README.
+The following are details about dockerfiles found in opencog and buildbot
+directories. On how to use read [opencog's README.MD](opencog/README.md) and
+[buildbot's README.md](buildbot/README.md).
+
+The Dockerfiles in the directories `opencog/tools/distcc`, `opencog/embodiment` and `opencog/cogserver` are not detailed because they are not in active use.
+
 
 ### Docker image structure:
 
     ├─opencog/opencog-deps:utopic
     ├─opencog/opencog-deps:latest
-      ├─opencog/opencog-dev:cli (for a dev environment)
-      ├─opencog/opencog-dev:ide
-      ├─opencog/opencog-buildslave
-      ├─opencog/opencog-distcc
-      ├─opencog/cogserver
-      ├─opencog/embodiment
-
-    ├─opencog/moses
+      ├─buildbot_* (Where * = atomspace, cogutils, opencog, moses)
+      ├─opencog/cogutils:latest
+        ├─opencog/opencog-dev:cli (for a dev environment)
+        ├─opencog/opencog-dev:ide
+        ├─opencog/moses
 
     ├─opencog/relex
 
@@ -89,30 +90,30 @@ as this README.
    dependencies installed.
 
 * `opencog/opencog-deps:latest`: ubuntu 14.04 based image with all OpenCog's
-   dependencies installed. This forms the base of other main repositories. It
-   likely will be updated to the latest LTS as it is released.
+   dependencies installed. This forms the base of opencog/cogutils. It
+   likely will be updated to the latest LTS as it is released. Has some command
+   line tools for use by developers.
+
+* `buildbot_*`: Is used for buildbot found [here](buildbot.opencog.org:8010)
+
+* `opencog/cogutils`: It is the base image for `opencog/opencog-dev:cli`,
+   `opencog/opencog-dev:ide` and `opencog/moses` images. It installs cogutils
+   over `opencog/opencog-deps` image. The main reason for having this is to
+   speed up rebuilds as one doesn't ave to rebuild the `opencog-deps` image,
+   unless there are dependency changes, and rebuilding this image will suffice
+   for updating the dependent images.
 
 * `opencog/opencog-dev:cli`: Mainly for running/developing through a shared
-   filesystem between host and container. Has some command line tools installed
+   filesystem between host and container.
 
-* `opencog/opencog-dev:ide`: Still in development. To be used for developing using
-   ides.
+* `opencog/opencog-dev:ide`: To be used for developing using ides. QtCreator
+   is installed.
 
-* `opencog/opencog-buildslave`: Is used for buildbot found [here] (buildbot.opencog.org:8010)
-   Needs some cleanup along with `opencog/opencog-distcc` `opencog/embodiment`
+* `opencog/moses`: It has moses and R installed. R is installed for those
+   who want to use the R binding for moses. The binding is not yet included but can be found [here](https://github.com/mjsduncan/Rmoses).
 
-* `opencog/cogserver`: Self-contained opencog cogserver. Has a shallow clone of
-   the OpenCog repo, which is built. On starting a container the default is to
-   start the cogserver.
-
-* `opencog/moses`: It is based on the offical r-base image and has moses installed.
-   The R binding to moses is not yet included but the binding can be found [here](https://github.com/mjsduncan/Rmoses)
-
-* `opencog/relex`: It is a self-contianed image for running relex and linkg-grammar
-   servers. For the time being it is also the development image so, you have to
-   use shared filesystem for development or clone your repo inside the container
-   or use a separte data-volume.
-
+* `opencog/relex`: It is a self-contianed image for running relex and      
+   linkg-grammar servers.
 
 ## 3. Usage
 * To run the demos and other containers, docker must be installed. Instructions
@@ -120,7 +121,7 @@ as this README.
   section on the page explains how to avoid having to use `sudo` all the time.
 
 * The docker-build.sh file in opencog directory is used for building some of the
-  base images.After running the script successfully other images could be built.
+  images. Run `./docker-build.sh -h` for viewing available options.
 
 * To use docker-compose follow the instruction in the README file in the
   opencog directory.

--- a/buildbot/README.md
+++ b/buildbot/README.md
@@ -14,11 +14,12 @@ related configurations. Buildbot is used for both.
 The buildbot that is running this configuration is found [here](http://buildbot.opencog.org:8010/)
 
 ## Usage
-Assuming you have installed docker and docker-compose run
-```
-docker-compose up
-```
-In your browser go to http://localhost:8010/waterfall
+1. Modify master/master.cfg to fit your needs.
+2. Assuming you have installed docker and docker-compose run
+   ```
+   docker-compose up
+   ```
+3. In your browser go to http://localhost:8010/waterfall
 
 
 ### TODO:

--- a/buildbot/cronjobs.sh
+++ b/buildbot/cronjobs.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Usage:
-#  ./cronjobs.sh $HOME/path/to/dir/to/workspace
+## 1 Modify the string of the variables TRIGGERED_COMMAND and then run the
+##   the following commands to trigger the commands every 5 minutes.
+## 2. crontab -e
+## 3.  */5 * * * * path/to/opencog/docker/clone/buildbot/cronjobs.sh ~
 
 # Environment Variables
 ## Name of script.

--- a/buildbot/cronjobs.sh
+++ b/buildbot/cronjobs.sh
@@ -136,10 +136,12 @@ fi
 ## and use one of the curl `Build Trigger` options listed in the examples.
 ## For opencog/opencog-deps docker image an example trigger command is,
 ## curl -H "Content-Type: application/json" --data '{"build": true}' -X POST https://registry.hub.docker.com/u/opencog/opencog-deps/trigger/45dfbf0e-9412-4c6b-b3fd-a864e92ee9f6/
+
+## For opencogopencog-deps docker image
 TRIGGERED_COMMAND='echo replace with the command for ocpkg repo'
 trigger_command ocpkg "$TRIGGERED_COMMAND"
 
-# For opencog/cogutils docker image
+## For opencog/cogutils docker image
 TRIGGERED_COMMAND="echo replace with the command for cogutils repo"
 trigger_command cogutils "$TRIGGERED_COMMAND"
 

--- a/buildbot/cronjobs.sh
+++ b/buildbot/cronjobs.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Usage:
+#  ./cronjobs.sh $HOME/path/to/dir/to/workspace
+
+# Environment Variables
+## Name of script.
+SELF_NAME=$(basename $0)
+
+## Path from which the script is invoked
+CWD=$(pwd)
+
+## Command to be run when condition are met. Modify it to suit your case.
+## For updating docker images go to the `Build Settings` tab on hub.docker.com
+## and use one of the curl `Build Trigger` options listed in the examples.
+TRIGGERED_COMMAND="echo triggered command not set"
+        #curl -H "Content-Type: application/json" --data '{"build": true}' -X POST https://registry.hub.docker.com/u/opencog/opencog-deps/trigger/45dfbf0e-9412-4c6b-b3fd-a864e92ee9f6/
+
+## File name where the output of this script is logged to. It would be in the
+## same directory.
+LOG_FILE=my.log
+
+#exec 2>&1 1>z.log
+
+
+# Functions
+## Check if the given repo has been cloned to the `cronjobs` directory. If it
+## hasn't then makes a shallow clone from github into `cronjobs` directory.
+## $1 : github opencog repository name. For eg. ocpkg for opencog/ocpkg repo.
+set_workspace(){
+    DIR_PATH=$WORKSPACE/cronjobs/$1
+    REPO_URL=https://github.com/opencog/$1.git
+
+    if [ -d $DIR_PATH ]; then
+        printf "Changing directory to %s \n" "$DIR_PATH"
+        cd $DIR_PATH
+
+        if [ "$(git rev-parse --is-inside-work-tree)" == true ] ; then
+            printf "%s contains a git repository \n" "$DIR_PATH"
+
+            # Just b/c it is named as the repo doesn't mean it has the given
+            # repo
+            REMOTE_ORIGIN="https:$(git remote show origin \
+                                | grep -i "Fetch URL" | cut -d ":" -f 3)"
+            echo $REMOTE_ORIGIN
+            echo $REPO_URL
+            if [ $REMOTE_ORIGIN == $REPO_URL ]; then
+                printf "%s already cloned to %s \n" "$REPO_URL" "$DIR_PATH"
+            else
+                printf "The repository in %s is not from %s \n" \
+                    "$DIR_PATH" "$REPO_URL"
+            fi
+        else
+            printf "%s does not contain a git repository \n" "$DIR_PATH"
+            cd -
+            rm -rf $DIR_PATH
+            printf "cloning %s to %s \n" "$1" "$DIR_PATH"
+            git clone --depth 1 $REPO_URL $DIR_PATH
+            cd $CWD
+        fi
+
+    else
+        printf "cloning %s to %s \n" "$1" "$DIR_PATH"
+        git clone --depth 1 $REPO_URL $DIR_PATH
+        cd $CWD
+    fi
+}
+
+# Main Execution
+printf "%s [%s] Starting ----------------------\n" "$(date)" "$SELF_NAME"
+
+## Convert the argument passed to an abslute path
+cd $1
+WORKSPACE=$(pwd)
+cd $CWD
+
+## prevent the scripts from running unless a path is passed to it.
+if [ -z $1 ]; then
+    printf "No argument passed \n"
+    cd $CWD
+    printf "%s [%s] Finished ----------------------\n" "$(date)" "$SELF_NAME"
+    exit 1
+fi
+
+## check if the directory given fits for a workspace. If it isn't a git
+## repostiroy then it fits.
+cd $WORKSPACE
+if [ "$(git rev-parse --is-inside-work-tree)" == true ] ; then
+    cd $WORKSPACE
+    printf "%s contains a git repository. Use another directory \n" "$(pwd)"
+    cd $CWD
+    printf "%s [%s] Finished ----------------------\n" "$(date)" "$SELF_NAME"
+    exit 1
+fi
+
+## For opencog/opencog-deps docker image
+TRIGGERED_COMMAND="echo ocpkg-trigger-replace-it"
+
+# For opencog/cogutils docker image
+TRIGGERED_COMMAND="echo ocpkg-trigger-replace-it"
+set_workspace ocpkg
+printf "%s [%s] Finished ----------------------\n" "$(date)" "$SELF_NAME"

--- a/opencog/README.md
+++ b/opencog/README.md
@@ -4,9 +4,9 @@ You can use docker-compose for configuring your workspace on linux and Mac syste
 
 ## Initial setups
 1. ./docker-build.sh [OPTIONS]
-    * For opencog development use -bt option
-    * If you want to update your images add -u option. For example for opencog
-      development use -btu
+    * For opencog development use -bct option
+    * If you want to update your images add `-u` option. For example for opencog
+      development use `-ctu` options. Unless there are some system dependency changes, you don't have to update `opeoncog/opencog-deps` image.
 2. sudo pip install -U docker-compose # only the first time
 3. Add these lines to .bashrc at $HOME of your PC and restart terminal or run `source ~/.bashrc` . __ Note that you don't have to clone each repository or add
 all the paths__ , just those you need. For the rest docker-compose will create


### PR DESCRIPTION
The cronjob is required as the Dockerfiles are found in this repo while the changes in various other repos should result in the update of the images.