### PR TITLE
Add jupyter notebook with python and guile kernel in tools. 

### DIFF
--- a/opencog/README.md
+++ b/opencog/README.md
@@ -141,6 +141,23 @@ __For UNIX like systems only, and if you choose to use docker-compose__
   * If you don't want to map ports to host run
      `docker-compose -f relex.yml run relex`
 
+## Steps for running jupyter kernels with opencog
+1. Build the image which has python and guile kernels installed with the following command.
+    ```
+    ./docker-build -j
+    ```
+This would build/pull necessary docker images.
+2. Add this lines to `./.bashrc` to point to your preferred notebooks save directory 
+
+    ``` 
+    export OPENCOG_NOTEBOOKS=$HOME/clone_dir/opencog_notebooks 
+    ```
+3. For starting jupyter notebook run the following command. 
+
+    ```
+    docker-compose -f opencog-jupyter.yml run --service-ports notes
+    ```
+4. Go to `0.0.0.0:8888/tree/notebooks` to interact with your notebooks and save them.
 <!--
 ## Steps for opencog-to-minecraft development
 __For UNIX like systems only, and if you choose to use docker-compose__

--- a/opencog/README.md
+++ b/opencog/README.md
@@ -151,7 +151,7 @@ This would build/pull necessary docker images.
 2. Add this lines to `./.bashrc` to point to your preferred notebooks save directory 
 
     ``` 
-    export OPENCOG_NOTEBOOKS=$HOME/clone_dir/opencog_notebooks 
+    export OPENCOG_NOTEBOOKS=$HOME/path/to/opencog_notebooks 
     ```
 3. For starting jupyter notebook run the following command. 
 

--- a/opencog/README.md
+++ b/opencog/README.md
@@ -147,6 +147,7 @@ __For UNIX like systems only, and if you choose to use docker-compose__
     ./docker-build -j
     ```
 This would build/pull necessary docker images.
+
 2. Add this lines to `./.bashrc` to point to your preferred notebooks save directory 
 
     ``` 
@@ -157,7 +158,7 @@ This would build/pull necessary docker images.
     ```
     docker-compose -f opencog-jupyter.yml run --service-ports notes
     ```
-4. Go to `0.0.0.0:8888/tree/notebooks` to interact with your notebooks and save them.
+4. Go to `0.0.0.0:8888/tree/notebooks` to interact with your notebooks.
 <!--
 ## Steps for opencog-to-minecraft development
 __For UNIX like systems only, and if you choose to use docker-compose__

--- a/opencog/docker-build.sh
+++ b/opencog/docker-build.sh
@@ -31,6 +31,7 @@ printf "Usage: ./%s [OPTIONS]
     -c Builds opencog/cogutil image. It will build opencog/opencog-deps
        if it hasn't been built, as it forms its base image.
     -e Builds opencog/minecraft image. It will build all needed images if they
+    -j Builds opencog/jupyter image. It will add jupyter notebook to opencog/opencog-dev
        haven't already been built.
     -m Builds opencog/moses image.
     -p Builds opencog/postgres image.
@@ -106,7 +107,7 @@ pull_dev_images() {
 # Main Execution
 if [ $# -eq 0 ] ; then NO_ARGS=true ; fi
 
-while getopts "abcehmprtu" flag ; do
+while getopts "abcehjmprtu" flag ; do
     case $flag in
         a) PULL_DEV_IMAGES=true ;;
         b) BUILD_OPENCOG_BASE_IMAGE=true ;;
@@ -116,6 +117,7 @@ while getopts "abcehmprtu" flag ; do
         m) BUILD__MOSES_IMAGE=true ;;
         p) BUILD__POSTGRES_IMAGE=true ;;
         r) BUILD_RELEX_IMAGE=true ;;
+        j) BUILD_JUPYTER_IMAGE=true ;;
         u) CACHE_OPTION=--no-cache ;;
         h) usage ;;
         \?) usage; exit 1 ;;
@@ -166,6 +168,13 @@ if [ $BUILD_RELEX_IMAGE ] ; then
     echo "---- Starting build of opencog/relex ----"
     docker build $CACHE_OPTION -t opencog/relex relex
     echo "---- Finished build of opencog/relex ----"
+fi
+
+if [ $BUILD_JUPYTER_IMAGE ]; then
+    check_dev_cli
+    echo "---- Starting build of opencog/jupyter ----"
+    docker build $CACHE_OPTION -t opencog/jupyter tools/jupyter_notebook
+    echo "---- Finished build of opencog/jupyter ----" 
 fi
 
 if [ $UNKNOWN_FLAGS ] ; then usage; exit 1 ; fi

--- a/opencog/docker-build.sh
+++ b/opencog/docker-build.sh
@@ -31,8 +31,8 @@ printf "Usage: ./%s [OPTIONS]
     -c Builds opencog/cogutil image. It will build opencog/opencog-deps
        if it hasn't been built, as it forms its base image.
     -e Builds opencog/minecraft image. It will build all needed images if they
-    -j Builds opencog/jupyter image. It will add jupyter notebook to opencog/opencog-dev
        haven't already been built.
+    -j Builds opencog/jupyter image. It will add jupyter notebook to opencog/opencog-dev:cli
     -m Builds opencog/moses image.
     -p Builds opencog/postgres image.
     -r Builds opencog/relex image.

--- a/opencog/opencog-jupyter.yml
+++ b/opencog/opencog-jupyter.yml
@@ -1,0 +1,31 @@
+# Follow the instructions below for setting using jupyter notebooks with opencog.
+#
+
+notes:
+    image: opencog/jupyter:latest
+    ports: 
+        - "17001:17001"
+        - "18001:18001"
+        - "8080:8080"
+        - "8888:8888"
+    working_dir: /opencog
+    volumes:
+        - $OPENCOG_SOURCE_DIR:/opencog
+        - $HOME/.gitconfig:/home/opencog/.gitconfig
+        - /tmp/.X11-unix/:/tmp/.X11-unix/:ro # For GUI
+        - $OPENCOG_NOTEBOOKS:/opencog/notebooks
+    environment: # Set environment variables within the container
+        - PYTHONPATH=/opencog/build/opencog/cython:/opencog/opencog/python/:/opencog/opencog/nlp/
+        - OPENCOG_SOURCE_DIR=/opencog
+postgres:
+    image: opencog/postgres
+    # Uncomment the following lines if you want to work on a production
+    # system.
+    # NOTE: The environment variable `PROD` is set `True` then the entrypoint
+    # script in opencog/postgres does additional configurations.
+    # environment:
+    #     - PROD=True
+
+relex:
+    image: opencog/relex
+    command: /bin/sh -c "./opencog-server.sh"

--- a/opencog/tools/jupyter_notebook/Dockerfile
+++ b/opencog/tools/jupyter_notebook/Dockerfile
@@ -1,0 +1,37 @@
+# For interacting with jupter notebooks. This installs a kernel for python and guile.
+
+# Build from opencog-dev:cli as it has all packages it needs.
+FROM opencog/opencog-dev:cli
+
+RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion \
+    curl python3-pip
+
+# To install jupyter notebook alongside with kernel on default python3 for later usage
+# torando must be at this specific version from https://github.com/jupyter/notebook/issues/3407
+RUN python3 -m pip install jupyter ipykernel tornado==4.5.3
+
+# Install guile-json as it is needed for guile-kernel
+WORKDIR /opt/
+
+RUN wget http://download.savannah.gnu.org/releases/guile-json/guile-json-0.6.0.tar.gz && \
+    tar xvf guile-json-0.6.0.tar.gz && \
+    rm guile-json-0.6.0.tar.gz && \
+    cd guile-json-0.6.0 && \
+    ./configure && \
+    make install
+
+# ZMQ library to enable communication with jupyter notebook
+RUN wget https://raw.githubusercontent.com/jerry40/guile-simple-zmq/master/src/simple-zmq.scm -O /usr/local/share/guile/site/simple-zmq.scm
+
+# Create a directory with the guile kernel in jupyter notebook kernels directory
+WORKDIR /usr/local/share/jupyter/kernels
+
+RUN git clone --depth 1 https://github.com/jerry40/guile-kernel
+# Copy kernel description to the above folder
+COPY kernel.json /usr/local/share/jupyter/kernels/guile-kernel
+
+EXPOSE 8888
+USER opencog
+CMD [ "jupyter", "notebook", "--ip=0.0.0.0", "--port=8888" ]

--- a/opencog/tools/jupyter_notebook/kernel.json
+++ b/opencog/tools/jupyter_notebook/kernel.json
@@ -1,0 +1,5 @@
+{
+    "argv": ["guile", "-s", "/usr/local/share/jupyter/kernels/guile-kernel/src/main.scm", "--", "{connection_file}"],
+    "display_name": "Guile",
+    "language": "scheme"
+}


### PR DESCRIPTION
This builds on top of opencog/opencog-dev:cli to add jupyter kernels with `ipykernel` for python and guile kernel from https://github.com/jerry40/guile-kernel. And may be more i.e haskell down the line. 
This could be run via
```
./docker-build -j
```
And spawning the container would follow (as outlined in the readme) 
```
export OPENCOG_NOTEBOOKS=$HOME/path/to/opencog_notebooks
docker-compose -f opencog-jupyter.yml run --service-ports notes
```
