### PR TITLE
Fix name issue with latest repo in jerry40

### DIFF
--- a/opencog/tools/jupyter_notebook/kernel.json
+++ b/opencog/tools/jupyter_notebook/kernel.json
@@ -1,5 +1,5 @@
 {
-    "argv": ["guile", "-s", "/usr/local/share/jupyter/kernels/guile-kernel/src/main.scm", "--", "{connection_file}"],
+    "argv": ["guile", "-s", "/usr/local/share/jupyter/kernels/guile-kernel/src/guile-jupyter-kernel.scm", "--", "{connection_file}"],
     "display_name": "Guile",
     "language": "scheme"
 }


### PR DESCRIPTION
Kernel doesn't work with latest repo as kernel argument has changed. This pull request fixes that. 