### PR TITLE
Add services line to docker-compose.yml and common.yml

### DIFF
--- a/opencog/common.yml
+++ b/opencog/common.yml
@@ -3,20 +3,22 @@
 # * minecraft.yml
 # NOTE: Don't add links in this file
 
-workspace:
-    image: opencog/opencog-dev:cli
-    ports: # syntax is host:container
-        - "5000:5000"
-        - "17001:17001"
-        - "8080:8080"
-    volumes:
-        - $OPENCOG_SOURCE_DIR:/opencog
-        - $HOME/.gitconfig:/home/opencog/.gitconfig # for git commits,stash ...
-        - ${ETC_LOCALTIME}:/etc/localtime:ro # for syncing with host time.
-        - $CCACHE_DIR:/home/opencog/.ccache # for persisting ccache artifacts
-    environment: # Set environment variables within the container
-        - OPENCOG_SOURCE_DIR=/opencog
-        - CCACHE_DIR=/home/opencog/.ccache
-        - PGHOST=db # This should be the same as the link's alias
-        - PGUSER=opencog_user # user created by configure-database.sh
-    command: bash
+services:
+    workspace:
+        image: opencog/opencog-dev:cli
+        ports: # syntax is host:container
+            - "5000:5000"
+            - "17001:17001"
+            - "8080:8080"
+        volumes:
+            - $OPENCOG_SOURCE_DIR:/opencog
+            - $HOME/.gitconfig:/home/opencog/.gitconfig # for git commits,stash ...
+            - ${ETC_LOCALTIME}:/etc/localtime:ro # for syncing with host time.
+            - $CCACHE_DIR:/home/opencog/.ccache # for persisting ccache artifacts
+        environment: # Set environment variables within the container
+            - OPENCOG_SOURCE_DIR=/opencog
+            - CCACHE_DIR=/home/opencog/.ccache
+            - PGHOST=db # This should be the same as the link's alias
+            - PGUSER=opencog_user # user created by configure-database.sh
+        command: bash
+

--- a/opencog/docker-compose.yml
+++ b/opencog/docker-compose.yml
@@ -1,31 +1,33 @@
 # Usage: Follow the steps in the README file in the directory containing this file
 
-dev:
-    extends:
-        file: common.yml
-        service: workspace
-    volumes:
-        - $ATOMSPACE_SOURCE_DIR:/atomspace
-        - $COGUTIL_SOURCE_DIR:/cogutil
-        # Uncomment the following lines if you want to work on moses
-        # - $MOSES_SOURCE_DIR:/moses
-    working_dir: /opencog # This is the same as the volume mount point below
-    environment:
-        - ATOMSPACE_SOURCE_DIR=/atomspace
-        - COGUTIL_SOURCE_DIR=/cogutil
-    links:
-        - postgres:db
-        - relex:relex
+services:
+    dev:
+        extends:
+            file: common.yml
+            service: workspace
+        volumes:
+            - $ATOMSPACE_SOURCE_DIR:/atomspace
+            - $COGUTIL_SOURCE_DIR:/cogutil
+            # Uncomment the following lines if you want to work on moses
+            # - $MOSES_SOURCE_DIR:/moses
+        working_dir: /opencog # This is the same as the volume mount point below
+        environment:
+            - ATOMSPACE_SOURCE_DIR=/atomspace
+            - COGUTIL_SOURCE_DIR=/cogutil
+        links:
+            - postgres:db
+            - relex:relex
 
-postgres:
-    image: opencog/postgres
-    # Uncomment the following lines if you want to work on a production
-    # system.
-    # NOTE: The environment variable `PROD` is set `True` then the entrypoint
-    # script in opencog/postgres does additional configurations.
-    # environment:
-    #     - PROD=True
+    postgres:
+        image: opencog/postgres
+        # Uncomment the following lines if you want to work on a production
+        # system.
+        # NOTE: The environment variable `PROD` is set `True` then the entrypoint
+        # script in opencog/postgres does additional configurations.
+        # environment:
+        #     - PROD=True
 
-relex:
-    image: opencog/relex
-    command: /bin/sh -c "./opencog-server.sh"
+    relex:
+        image: opencog/relex
+        command: /bin/sh -c "./opencog-server.sh"
+


### PR DESCRIPTION
Services line is needed for current docker-compose formatting requirements. Similar fixes might need to be applied to other .yml files, this just makes sure the opencog image and basic dependencies can run.